### PR TITLE
fix showing non-editable fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [2.1.14] - unreleased
 
+### Fixed
+
+* Showing the `link-formula`, `creator`, `last-modifier` and `button` columns in Create Row and Update Row action.
+
 ### Internal
 
 * Stabilize tests; SeaTable 3.5.10

--- a/src/ctx.js
+++ b/src/ctx.js
@@ -48,7 +48,7 @@ const struct = {
     },
     zapier: {
       // column types that zapier must not write/create (hidden):
-      hide_write: ['file', 'image', 'link', 'auto-number', 'ctime', 'mtime', 'formula'],
+      hide_write: ['file', 'image', 'link', 'auto-number', 'ctime', 'mtime', 'formula', 'link-formula', 'creator', 'last-modifier', 'button'],
       // column types that zapier should not offer to search in (hidden):
       hide_search: ['link'],
       /**


### PR DESCRIPTION
hide the `link-formula`, `creator`, `last-modifier` and `button` columns in create row and update row action.

* Report-Record: https://cloud.seatable.io/workspace/925/dtable/Zapier%20Feedback/?tid=qw23&vid=0000&row-id=VXd8OBcqQVW4Y5no3J9_KA
* On Zapier as *SeaTable **2.1.14***